### PR TITLE
Added document reference without manifest

### DIFF
--- a/med-mij/me.digi/v1/default/document-reference/1.json
+++ b/med-mij/me.digi/v1/default/document-reference/1.json
@@ -204,5 +204,108 @@
         ],
         "accountentityid": "37_123456789",
         "entityid": "37_123456789_pdfa-documentreference2"
+    },
+    {
+        "resourceType": "DocumentReference",
+        "id": "pdfa-documentreference4",
+        "meta": {
+            "versionId": "1",
+            "lastUpdated": "2023-09-04T01:56:12.975-04:00",
+            "profile": [
+                "http://nictiz.nl/fhir/StructureDefinition/IHE.MHD.Minimal.DocumentReference"
+            ]
+        },
+        "text": {
+            "status": "extensions",
+            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table><caption>DocumentReference. Subject: Johan XXX_Helleman. Set‑Id: urn:oid:1.2.276.0.7230010.3.1.2.1787205428.3024.1522314975.287798 (urn:ietf:rfc:3986), Id: 852852 (http://xis.org/fhir/NamingSystem/DocumentReferenceID), Status: actueel                              \n          <span style=\"display: block;\">Auteur: A.F. Snijder</span></caption><tbody><tr><th>Type</th><td><span title=\"Samenvattende ontslagbrief [bevinding] in {instelling} d.m.v. allergie+immunologie (document) (68626-1 - LOINC)\">Samenvattende ontslagbrief [bevinding] in {instelling} d.m.v. allergie+immunologie (document)</span></td></tr><tr><th>Geïndexeerd</th><td>2022-10-19T00:00:00+01:00</td></tr><tr><th>Securitylabel</th><td/></tr><tr><th>Omschrijving</th><td>Discharge summary</td></tr><tr><th>Content</th><td><img src=\"https://informatiestandaarden.nictiz.nl/images/2/29/Example_PDF_-_Discharge_Summary.pdf\" alt=\"null\" title=\"Example PDF - Discharge Summary\"/></td></tr></tbody></table></div>"
+        },
+        "contained": [
+            {
+                "resourceType": "Practitioner",
+                "id": "p1",
+                "name": [
+                    {
+                        "family": "Snijder",
+                        "given": [
+                            "A.F."
+                        ],
+                        "_given": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier",
+                                        "valueCode": "IN"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "masterIdentifier": {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:1.2.276.0.7230010.3.1.2.1787205428.3024.1522314975.287798"
+        },
+        "identifier": [
+            {
+                "system": "http://xis.org/fhir/NamingSystem/DocumentReferenceID",
+                "value": "852852"
+            }
+        ],
+        "status": "current",
+        "type": {
+            "coding": [
+                {
+                    "system": "http://loinc.org",
+                    "code": "68626-1",
+                    "display": "Samenvattende ontslagbrief [bevinding] in {instelling} d.m.v. allergie+immunologie (document)"
+                }
+            ]
+        },
+        "class": {
+            "coding": [
+                {
+                    "system": "http://loinc.org",
+                    "code": "18842-5",
+                    "display": "Discharge summary"
+                }
+            ]
+        },
+        "subject": {
+            "reference": "Patient/medmij-bgz-patient-ts-01",
+            "display": "Johan XXX_Helleman"
+        },
+        "indexed": "2022-10-19T00:00:00+01:00",
+        "author": [
+            {
+                "reference": "#p1",
+                "display": "A.F. Snijder"
+            }
+        ],
+        "description": "Discharge summary",
+        "securityLabel": [
+            {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/v3/Confidentiality",
+                        "code": "V",
+                        "display": "very restricted"
+                    }
+                ]
+            }
+        ],
+        "content": [
+            {
+                "attachment": {
+                    "contentType": "application/pdf",
+                    "language": "en",
+                    "url": "https://informatiestandaarden.nictiz.nl/images/2/29/Example_PDF_-_Discharge_Summary.pdf",
+                    "title": "Example PDF - Discharge Summary"
+                }
+            }
+        ],
+        "accountentityid": "37_123456789",
+        "entityid": "37_123456789_pdfa-documentreference4"
     }
 ]


### PR DESCRIPTION
Added one DocumentReference example without link to DocumentManifest. The content is linked via url, not Binary